### PR TITLE
fix(tauri) embedded-server edge case with config host

### DIFF
--- a/lib/rust/src/app.rs
+++ b/lib/rust/src/app.rs
@@ -4,7 +4,7 @@ use tauri_ui::WebView;
 //type FnMut(&mut InvokeHandler<WebView<'_, ()>>, &str) = FnMut(&mut FnMut(&mut InvokeHandler<WebView<'_, ()>>, &str)<WebView<'_, ()>>, &str);
 
 pub struct App {
-  invoke_handler: Option<Box<dyn FnMut(&mut WebView<'_, ()>, &str)>>
+  invoke_handler: Option<Box<dyn FnMut(&mut WebView<'_, ()>, &str)>>,
 }
 
 impl App {
@@ -14,33 +14,36 @@ impl App {
 
   pub fn run_invoke_handler(&mut self, webview: &mut WebView<'_, ()>, arg: &str) {
     match self.invoke_handler {
-      Some(ref mut invoke_handler)  => {
+      Some(ref mut invoke_handler) => {
         invoke_handler(webview, arg);
-      },
+      }
       None => {}
     }
   }
 }
 
 pub struct AppBuilder {
-  invoke_handler: Option<Box<dyn FnMut(&mut WebView<'_, ()>, &str)>>
+  invoke_handler: Option<Box<dyn FnMut(&mut WebView<'_, ()>, &str)>>,
 }
 
 impl AppBuilder {
   pub fn new() -> Self {
     Self {
-      invoke_handler: None
+      invoke_handler: None,
     }
   }
 
-  pub fn invoke_handler<F: FnMut(&mut WebView<'_, ()>, &str) + 'static>(mut self, invoke_handler: F) -> Self {
+  pub fn invoke_handler<F: FnMut(&mut WebView<'_, ()>, &str) + 'static>(
+    mut self,
+    invoke_handler: F,
+  ) -> Self {
     self.invoke_handler = Some(Box::new(invoke_handler));
     self
   }
 
   pub fn build(self) -> App {
     App {
-      invoke_handler: self.invoke_handler
+      invoke_handler: self.invoke_handler,
     }
   }
 }

--- a/lib/rust/src/config.rs
+++ b/lib/rust/src/config.rs
@@ -42,7 +42,7 @@ pub struct EmbeddedServerConfig {
   #[serde(default = "default_host")]
   pub host: String,
   #[serde(default = "default_port")]
-  pub port: String
+  pub port: String,
 }
 
 fn default_host() -> String {
@@ -56,7 +56,7 @@ fn default_port() -> String {
 fn default_embedded_server() -> EmbeddedServerConfig {
   EmbeddedServerConfig {
     host: default_host(),
-    port: default_port()
+    port: default_port(),
   }
 }
 
@@ -66,7 +66,7 @@ pub struct Config {
   #[serde(default = "default_window")]
   pub window: WindowConfig,
   #[serde(default = "default_embedded_server")]
-  pub embedded_server: EmbeddedServerConfig
+  pub embedded_server: EmbeddedServerConfig,
 }
 
 pub fn get() -> Config {

--- a/lib/rust/src/event.rs
+++ b/lib/rust/src/event.rs
@@ -1,7 +1,7 @@
-use tauri_ui::Handle;
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use tauri_ui::Handle;
 
 struct EventHandler {
   on_event: Box<dyn FnOnce(String)>,

--- a/lib/rust/src/lib.rs
+++ b/lib/rust/src/lib.rs
@@ -11,6 +11,7 @@ extern crate includedir;
 extern crate phf;
 
 pub mod api;
+mod app;
 pub mod command;
 pub mod config;
 pub mod dir;
@@ -22,12 +23,11 @@ pub mod platform;
 pub mod process;
 pub mod rpc;
 pub mod salt;
+#[cfg(feature = "embedded-server")]
+pub mod server;
 pub mod tcp;
 pub mod updater;
 pub mod version;
-#[cfg(feature = "embedded-server")]
-pub mod server;
-mod app;
 pub use app::*;
 
 use tauri_ui::WebView;

--- a/lib/rust/src/salt.rs
+++ b/lib/rust/src/salt.rs
@@ -1,5 +1,5 @@
-use tauri_ui::WebView;
 use std::sync::Mutex;
+use tauri_ui::WebView;
 use uuid::Uuid;
 
 struct Salt {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/tauri/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

There's an edge case for how the webview and our embeddedServer loads its URLs.
When the config -> host is set to something like `localhost` or `127.0.0.1` (without http:// protocol), the server starts correctly, but the webview doesn't. We have to explicitely set the http protocol on the webview, but not on the embedded web server.

So, with this PR, we add the protocol for the webview load URL if its not there, and we always remove it from the config host. With this approach, the embedded web server MUST be served locally.

There are some other changes because I ran cargofmt.